### PR TITLE
🔥 Removed url argument from the DataLoader methods

### DIFF
--- a/stgraph/dataset/dynamic/england_covid_dataloader.py
+++ b/stgraph/dataset/dynamic/england_covid_dataloader.py
@@ -40,8 +40,6 @@ class EnglandCovidDataLoader(STGraphDynamicDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 8)
     cutoff_time : int, optional
@@ -53,26 +51,13 @@ class EnglandCovidDataLoader(STGraphDynamicDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset for each timestamp
-    _edge_weights : list
-        List of edge weights for each timestamp
-    _all_features : list
-        Node features for each timestamp minus lags
-    _all_targets : list
-        Node target value for each timestamp minus lags
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: EnglandCovidDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 8,
         cutoff_time: int | None = None,
         redownload: bool = False,
@@ -81,6 +66,7 @@ class EnglandCovidDataLoader(STGraphDynamicDataset):
         super().__init__()
 
         self.name = "England_COVID"
+        self._url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/england_covid.json"
         self._verbose = verbose
         self._lags = lags
         self._cutoff_time = cutoff_time
@@ -88,11 +74,6 @@ class EnglandCovidDataLoader(STGraphDynamicDataset):
         self._all_targets = None
         self._edge_list = None
         self._edge_weights = None
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/england_covid.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/static/cora_dataloader.py
+++ b/stgraph/dataset/static/cora_dataloader.py
@@ -52,8 +52,6 @@ class CoraDataLoader(STGraphStaticDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     redownload : bool, optional (default is False)
         Redownload the dataset online and save to cache
 
@@ -61,35 +59,26 @@ class CoraDataLoader(STGraphStaticDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _edge_list : np.ndarray
-        The edge list of the graph dataset
-    _all_features : np.ndarray
-        Numpy array of the node features
-    _all_targets : np.ndarray
-        Numpy array of the node target features
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: CoraDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         redownload: bool = False,
     ) -> None:
         """Citation network consisting of scientific publications."""
         super().__init__()
 
         self.name = "Cora"
+        self._url = (
+            "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/cora.json"
+        )
         self._verbose = verbose
         self._edge_list = None
         self._all_features = None
         self._all_targets = None
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/cora.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/hungarycp_dataloader.py
+++ b/stgraph/dataset/temporal/hungarycp_dataloader.py
@@ -45,8 +45,6 @@ class HungaryCPDataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 4)
     cutoff_time : int, optional
@@ -58,24 +56,13 @@ class HungaryCPDataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: HungaryCPDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 4,
         cutoff_time: int | None = None,
         redownload: bool = False,
@@ -94,17 +81,13 @@ class HungaryCPDataLoader(STGraphTemporalDataset):
             raise ValueError("cutoff_time must be a positive integer")
 
         self.name = "Hungary_Chickenpox"
+        self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/HungaryCP.json"
         self._verbose = verbose
         self._lags = lags
         self._cutoff_time = cutoff_time
         self._edge_list = None
         self._edge_weights = None
         self._all_targets = None
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/HungaryCP.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/metrla_dataloader.py
+++ b/stgraph/dataset/temporal/metrla_dataloader.py
@@ -52,8 +52,6 @@ class METRLADataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     num_timesteps_in : int, optional
         The number of timesteps the sequence model sees (default is 12)
     num_timesteps_out : int, optional
@@ -67,28 +65,13 @@ class METRLADataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _num_timesteps_in : int
-        The number of timesteps the sequence model sees
-    _num_timesteps_out : int
-        The number of timesteps the sequence model has to predict
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_features : numpy.ndarray
-        Numpy array of the node feature value
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: METRLADataLoader,
         verbose: bool = True,
-        url: str | None = None,
         num_timesteps_in: int = 12,
         num_timesteps_out: int = 12,
         cutoff_time: int | None = None,
@@ -113,6 +96,7 @@ class METRLADataLoader(STGraphTemporalDataset):
             raise ValueError("cutoff_time must be a positive integer")
 
         self.name = "METRLA"
+        self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/METRLA.json"
         self._verbose = verbose
         self._num_timesteps_in = num_timesteps_in
         self._num_timesteps_out = num_timesteps_out
@@ -121,11 +105,6 @@ class METRLADataLoader(STGraphTemporalDataset):
         self._edge_weights = None
         self._all_features = None
         self._all_targets = None
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/METRLA.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/montevideobus_dataloader.py
+++ b/stgraph/dataset/temporal/montevideobus_dataloader.py
@@ -53,8 +53,6 @@ class MontevideoBusDataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 4)
     cutoff_time : int, optional
@@ -66,26 +64,13 @@ class MontevideoBusDataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
-    _all_features : numpy.ndarray
-        Numpy array of the node feature value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: MontevideoBusDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 4,
         cutoff_time: int | None = None,
         redownload: bool = False,
@@ -106,14 +91,10 @@ class MontevideoBusDataLoader(STGraphTemporalDataset):
             raise ValueError("cutoff_time must be greater than lags")
 
         self.name = "Montevideo_Bus"
+        self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/montevideobus.json"
         self._verbose = verbose
         self._lags = lags
         self._cutoff_time = cutoff_time
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/montevideobus.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/pedalme_dataloader.py
+++ b/stgraph/dataset/temporal/pedalme_dataloader.py
@@ -45,8 +45,6 @@ class PedalMeDataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 4)
     cutoff_time : int, optional
@@ -58,24 +56,13 @@ class PedalMeDataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: PedalMeDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 4,
         cutoff_time: int | None = None,
         redownload: bool = False,
@@ -96,14 +83,10 @@ class PedalMeDataLoader(STGraphTemporalDataset):
             raise ValueError("cutoff_time must be greater than lags")
 
         self.name = "PedalMe"
+        self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/pedalme.json"
         self._verbose = verbose
         self._lags = lags
         self._cutoff_time = cutoff_time
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/pedalme.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/wikimath_dataloader.py
+++ b/stgraph/dataset/temporal/wikimath_dataloader.py
@@ -52,8 +52,6 @@ class WikiMathDataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 8)
     cutoff_time : int, optional
@@ -65,24 +63,13 @@ class WikiMathDataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: WikiMathDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 8,
         cutoff_time: int | None = None,
         redownload: bool = False,
@@ -101,14 +88,10 @@ class WikiMathDataLoader(STGraphTemporalDataset):
             raise ValueError("cutoff_time must be a positive integer")
 
         self.name = "WikiMath"
+        self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/wikivital_mathematics.json"
         self._verbose = verbose
         self._lags = lags
         self._cutoff_time = cutoff_time
-
-        if not url:
-            self._url = "https://raw.githubusercontent.com/bfGraph/STGraph-Datasets/main/wikivital_mathematics.json"
-        else:
-            self._url = url
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()

--- a/stgraph/dataset/temporal/windmilloutput_dataloader.py
+++ b/stgraph/dataset/temporal/windmilloutput_dataloader.py
@@ -67,8 +67,6 @@ class WindmillOutputDataLoader(STGraphTemporalDataset):
     ----------
     verbose : bool, optional
         Flag to control whether to display verbose info (default is False)
-    url : str, optional
-        The URL from where the dataset is downloaded online (default is None)
     lags : int, optional
         The number of time lags (default is 8)
     cutoff_time : int, optional
@@ -82,24 +80,13 @@ class WindmillOutputDataLoader(STGraphTemporalDataset):
     ----------
     name : str
         The name of the dataset.
-    _verbose : bool
-        Flag to control whether to display verbose info.
-    _lags : int
-        The number of time lags
-    _cutoff_time : int
-        The cutoff timestamp for the temporal dataset
-    _edge_list : list
-        The edge list of the graph dataset
-    _edge_weights : numpy.ndarray
-        Numpy array of the edge weights
-    _all_targets : numpy.ndarray
-        Numpy array of the node target value
+    gdata : dict
+        Graph meta data.
     """
 
     def __init__(
         self: WindmillOutputDataLoader,
         verbose: bool = False,
-        url: str | None = None,
         lags: int = 8,
         cutoff_time: int | None = None,
         size: str = "large",
@@ -138,10 +125,7 @@ class WindmillOutputDataLoader(STGraphTemporalDataset):
             "small": "https://graphmining.ai/temporal_datasets/windmill_output_small.json",
         }
 
-        if not url:
-            self._url = size_urls[self._size]
-        else:
-            self._url = url
+        self._url = size_urls[self._size]
 
         if redownload and self._has_dataset_cache():
             self._delete_cached_dataset()


### PR DESCRIPTION
In the new dataset abstraction, we had introduced a `url` argument, where the user can pass their own url from where the dataset can get downloaded from, other than the default download url. This is however a security vulnerability, where someone can pass a link to some malicious content that can then get downloaded to the users machine.

Also removed docs about the private attributes in the docstrings for the dataloaders.